### PR TITLE
Merge to ddd3502 on Oct 15, 2015 : Fixed GCC 4.9.2 compilation issues

### DIFF
--- a/include/gtest/internal/gtest-internal.h
+++ b/include/gtest/internal/gtest-internal.h
@@ -925,6 +925,13 @@ typedef char IsNotContainer;
 template <class C>
 IsNotContainer IsContainerTest(...) { return '\0'; }
 
+// EnableIf<condition>::type is void when 'Cond' is true, and
+// undefined when 'Cond' is false.  To use SFINAE to make a function
+// overload only apply when a particular expression is true, add
+// "typename EnableIf<expression>::type* = 0" as the last parameter.
+template<bool> struct EnableIf;
+template<> struct EnableIf<true> { typedef void type; };  // NOLINT
+
 // Utilities for native arrays.
 
 // ArrayEq() compares two k-dimensional native arrays using the


### PR DESCRIPTION
Backported some lines from the head (7f4448f) of the Google Test repository so
that the features RAMCloud uses will compile without warning. Note that this
commit doesn't fix all 4.9.2 compilation warnings, just the ones that affect
RAMCloud. This commit will also compile on GCC 4.4.7.
